### PR TITLE
Fix navbar language selection

### DIFF
--- a/F1/src/app/components/navbar/navbar.ts
+++ b/F1/src/app/components/navbar/navbar.ts
@@ -2,6 +2,7 @@ import { Component, Output, EventEmitter, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { HttpClient, HttpClientModule } from '@angular/common/http';
 import { Router, RouterModule } from '@angular/router';
+import { LanguageService } from '../../services/language.service';
 
 @Component({
   selector: 'app-navbar',
@@ -30,8 +31,12 @@ export class Navbar implements OnInit {  showMenu = false;
   ];
   @Output() langChange = new EventEmitter<'es' | 'en'>();
 
-  constructor(private http: HttpClient, private router: Router) {}
+  constructor(private http: HttpClient, private router: Router,
+              private langService: LanguageService) {
+    this.lang = this.langService.currentLang;
+  }
   ngOnInit() {
+    this.langService.lang$.subscribe(l => (this.lang = l));
     this.http.get('https://api.openf1.org/v1/teams').subscribe(data => this.teamsInfo = data as any[]);
     this.http.get('https://api.openf1.org/v1/drivers').subscribe(data => this.driversInfo = data as any[]);
     this.http.get('https://api.openf1.org/v1/sessions').subscribe(data => this.calendar = data as any[]);
@@ -82,7 +87,7 @@ export class Navbar implements OnInit {  showMenu = false;
   }
 
   setLang(lang: 'es' | 'en') {
-    this.lang = lang;
+    this.langService.setLang(lang);
     this.langChange.emit(lang);
     this.showMenu = false;
   }

--- a/F1/src/app/pages/home/home.ts
+++ b/F1/src/app/pages/home/home.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { TeamList } from '../../components/team-list/team-list';
+import { LanguageService } from '../../services/language.service';
 
 @Component({
   selector: 'app-home',
@@ -11,6 +12,8 @@ import { TeamList } from '../../components/team-list/team-list';
 export class Home {
   lang: 'es' | 'en' = 'es';
 
-  // This will now be coordinated with app-level language settings
-  // The language change is managed by the navbar component
+  constructor(private langService: LanguageService) {
+    this.lang = this.langService.currentLang;
+    this.langService.lang$.subscribe(l => (this.lang = l));
+  }
 }

--- a/F1/src/app/services/language.service.ts
+++ b/F1/src/app/services/language.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class LanguageService {
+  private langSubject = new BehaviorSubject<'es' | 'en'>('es');
+  readonly lang$ = this.langSubject.asObservable();
+
+  setLang(lang: 'es' | 'en') {
+    this.langSubject.next(lang);
+  }
+
+  get currentLang(): 'es' | 'en' {
+    return this.langSubject.getValue();
+  }
+}


### PR DESCRIPTION
## Summary
- add a LanguageService to hold the selected language
- make Navbar use the service and Home subscribe to it

## Testing
- `npm test` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_68401ec93f28832f8bd179c4b64849eb