### PR TITLE
Add numeric arrow hints

### DIFF
--- a/F1/README.md
+++ b/F1/README.md
@@ -12,6 +12,13 @@ ng serve
 
 Once the server is running, open your browser and navigate to `http://localhost:4200/`. The application will automatically reload whenever you modify any of the source files.
 
+### Mini-game hints
+
+In the Wordle F1 mini-game, incorrect numeric guesses show an arrow instead of an `X`:
+
+- `⬆` means the real value is higher than your guess.
+- `⬇` means the real value is lower.
+
 ## Code scaffolding
 
 Angular CLI includes powerful code scaffolding tools. To generate a new component, run:

--- a/F1/src/app/pages/drivers/drivers.html
+++ b/F1/src/app/pages/drivers/drivers.html
@@ -165,9 +165,11 @@
       <li>📊 Usa las pistas de color para acercarte:</li>
       <li class="color-guide">
         <span class="correct">🟢 Correcto</span>
-        <span class="partial">🟡 Cerca</span>
         <span class="wrong">🔴 Incorrecto</span>
+        <span class="higher">⬆ Mayor</span>
+        <span class="lower">⬇ Menor</span>
       </li>
+      <li>⬆ indica que el dato real es mayor, ⬇ que es menor</li>
       <li>🏁 Tienes {{ maxGuesses }} intentos para acertar</li>
     </ul>
   </div>

--- a/F1/src/app/pages/drivers/drivers.scss
+++ b/F1/src/app/pages/drivers/drivers.scss
@@ -218,14 +218,9 @@
     box-shadow: 0 4px 15px rgba(76, 175, 80, 0.3);
   }
   
-  &.partial {
-    background: linear-gradient(135deg, #FF9800, #f57c00);
-    color: white;
-    border-color: #FF9800;
-    box-shadow: 0 4px 15px rgba(255, 152, 0, 0.3);
-  }
-  
-  &.wrong {
+  &.wrong,
+  &.higher,
+  &.lower {
     background: linear-gradient(135deg, #f44336, #d32f2f);
     color: white;
     border-color: #f44336;
@@ -410,12 +405,9 @@
             color: white;
           }
           
-          &.partial {
-            background: #FF9800;
-            color: white;
-          }
-          
-          &.wrong {
+          &.wrong,
+          &.higher,
+          &.lower {
             background: #f44336;
             color: white;
           }

--- a/F1/src/app/pages/drivers/drivers.ts
+++ b/F1/src/app/pages/drivers/drivers.ts
@@ -30,10 +30,10 @@ interface GameGuess {
   nameMatch: 'correct' | 'wrong';
   teamMatch: 'correct' | 'wrong';
   nationalityMatch: 'correct' | 'wrong';
-  ageMatch: 'correct' | 'partial' | 'wrong';
-  firstYearMatch: 'correct' | 'partial' | 'wrong';
-  championshipsMatch: 'correct' | 'partial' | 'wrong';
-  winsMatch: 'correct' | 'partial' | 'wrong';
+  ageMatch: 'correct' | 'higher' | 'lower';
+  firstYearMatch: 'correct' | 'higher' | 'lower';
+  championshipsMatch: 'correct' | 'higher' | 'lower';
+  winsMatch: 'correct' | 'higher' | 'lower';
 }
 
 @Component({
@@ -347,18 +347,16 @@ export class DriversComponent implements OnInit {
     };
   }
 
-  compareNumbers(guess: number, target: number): 'correct' | 'partial' | 'wrong' {
+  compareNumbers(guess: number, target: number): 'correct' | 'higher' | 'lower' {
     if (guess === target) return 'correct';
-    // For partial feedback, show if the guess is within a certain range
-    const diff = Math.abs(guess - target);
-    if (diff <= 2) return 'partial'; // Close values
-    return 'wrong';
+    return guess < target ? 'higher' : 'lower';
   }
 
   getFeedbackIcon(feedback: string): string {
     switch (feedback) {
       case 'correct': return '✓';
-      case 'partial': return '~';
+      case 'higher': return '⬆';
+      case 'lower': return '⬇';
       default: return '✗';
     }
   }


### PR DESCRIPTION
## Summary
- show arrows (⬆ ⬇) for numeric values in the driver guessing game
- update instructions to mention the new hints

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684021d18304832fb3e5a7957a8a292c