### PR TITLE
Fix animations for driver guessing

### DIFF
--- a/F1/src/app/app.config.ts
+++ b/F1/src/app/app.config.ts
@@ -1,5 +1,6 @@
 import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZonelessChangeDetection } from '@angular/core';
 import { provideClientHydration, withEventReplay } from '@angular/platform-browser';
+import { provideAnimations } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
 import { provideHttpClient, withFetch } from '@angular/common/http';
 import { appRoutes } from './app.routes';
@@ -11,5 +12,6 @@ export const appConfig: ApplicationConfig = {
     provideClientHydration(withEventReplay()),
     provideRouter(appRoutes),
     provideHttpClient(withFetch()),
+    provideAnimations(),
   ]
 };

--- a/F1/src/app/pages/drivers/drivers.ts
+++ b/F1/src/app/pages/drivers/drivers.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { trigger, transition, style, animate } from '@angular/animations';
 import { FormsModule } from '@angular/forms';
 import { HttpClient } from '@angular/common/http';
 
@@ -41,7 +42,15 @@ interface GameGuess {
   standalone: true,
   imports: [CommonModule, FormsModule],
   templateUrl: './drivers.html',
-  styleUrl: './drivers.scss'
+  styleUrl: './drivers.scss',
+  animations: [
+    trigger('slideIn', [
+      transition(':enter', [
+        style({ opacity: 0, transform: 'translateY(-10px)' }),
+        animate('300ms ease-out', style({ opacity: 1, transform: 'translateY(0)' }))
+      ])
+    ])
+  ]
 })
 export class DriversComponent implements OnInit {
   // Game state


### PR DESCRIPTION
## Summary
- enable Angular animations in app config
- add slideIn animation trigger for guess rows

## Testing
- `npm test` *(fails: No binary for Chrome)*

------
https://chatgpt.com/codex/tasks/task_e_68402eecc8a4832f9a673c763d48f0d4